### PR TITLE
fix: only include *.ts files in lintTree

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 /* eslint-env node */
 'use strict';
 
+const TSLint = require('broccoli-tslinter');
+const Funnel = require('broccoli-funnel');
+
 module.exports = {
   name: 'ember-cli-tslint',
 
@@ -9,10 +12,9 @@ module.exports = {
       return undefined;
     }
 
-    const TSLint = require('broccoli-tslinter');
-
-
-    return new TSLint(tree, {
-    });
+    return new TSLint(
+      new Funnel(tree, { include: ['**/*.ts'] }),
+      {}
+    );
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 /* eslint-env node */
 'use strict';
 
-const TSLint = require('broccoli-tslinter');
-const Funnel = require('broccoli-funnel');
-
 module.exports = {
   name: 'ember-cli-tslint',
 
@@ -11,6 +8,10 @@ module.exports = {
     if (type === 'templates') {
       return undefined;
     }
+
+    // NOTE: intentionally inlined to improve ember-cli startup performance.
+    const TSLint = require('broccoli-tslinter');
+    const Funnel = require('broccoli-funnel');
 
     return new TSLint(
       new Funnel(tree, { include: ['**/*.ts'] }),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "mocha node-tests --recursive"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.1",
     "broccoli-tslinter": "^3.0.1",
     "rsvp": "^4.7.0",
     "tslint": "^5.5.0",


### PR DESCRIPTION
When using non-default Babel features (like `@decorators`) that require extra syntax plugins in remaining `*.js` files, `ember serve` fails with this error:

```
Finished linting 1 successfully
Build Error (Babel)

ddg.sh/tests/components/index-button/component.js: Unexpected token (5:0)

  3 | import { argument } from '@ember-decorators/argument';
  4 |
> 5 | @tagName('button')
    | ^
  6 | export default class IndexButtonComponent extends Component {
  7 |
  8 | }


    at Parser.pp$5.raise (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:4454:13)
    at Parser.pp.unexpected (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1761:8)
    at Parser.pp$1.parseDecorator (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1939:10)
    at Parser.pp$1.parseDecorators (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1924:26)
    at Parser.pp$1.parseStatement (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1818:10)
    at Parser.pp$1.parseBlockBody (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:2268:21)
    at Parser.pp$1.parseTopLevel (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1778:8)
    at Parser.parse (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:1673:17)
    at parse (/home/jan/gitlab/static/default/node_modules/babylon/lib/index.js:7305:37)
    at File.parse (/home/jan/gitlab/static/default/node_modules/babel-core/lib/transformation/file/index.js:517:15)
    at File.parseCode (/home/jan/gitlab/static/default/node_modules/babel-core/lib/transformation/file/index.js:602:20)
    at /home/jan/gitlab/static/default/node_modules/babel-core/lib/transformation/pipeline.js:49:12
    at File.wrap (/home/jan/gitlab/static/default/node_modules/babel-core/lib/transformation/file/index.js:564:16)
    at Pipeline.transform (/home/jan/gitlab/static/default/node_modules/babel-core/lib/transformation/pipeline.js:47:17)
    at Promise (/home/jan/gitlab/static/default/node_modules/broccoli-babel-transpiler/lib/parallel-api.js:123:26)
    at initializePromise (/home/jan/gitlab/static/default/node_modules/rsvp/dist/rsvp.js:567:5)
```

Removing `ember-cli-tslint` fixes the problem. So does always returning `undefined` for the `lintTree`:

https://github.com/t-sauer/ember-cli-tslint/blob/dd1b25e5b68f8de3895c1f6c01a53d537b662c33/index.js#L7-L17

Evidently, ember-cli or something other down the line is trying to invoke Babel for the remaining `*.js` files that are part of the `lintTree`, without passing the host project's Babel config.

This PR excludes any non `*.ts` files from the `lintTree` before passing it to `TSLint`:

```js
return new TSLint(
  new Funnel(tree, { include: ['**/*.ts'] }),
  {}
);
```

The returned `lintTree` therefore contains no `*.js` files and does not invoke Babel.